### PR TITLE
[fix] Use underscore instead of camel-case in actionlib call

### DIFF
--- a/rosplan_demos_interfaces/rosplan_interface_movebase_py/src/rosplan_interface_movebase_py/rosplan_interface_movebase.py
+++ b/rosplan_demos_interfaces/rosplan_interface_movebase_py/src/rosplan_interface_movebase_py/rosplan_interface_movebase.py
@@ -90,7 +90,7 @@ class RPMoveBasePy(RPActionInterface):
                 return False
         else:
             # timed out (failed)
-            self.action_client.cancelAllGoals()
+            self.action_client.cancel_all_goals()
             rospy.loginfo('KCL: ({}) action timed out'.format(self.params.name))
             return False
 


### PR DESCRIPTION
The API call should be cancel_all_goals, see https://github.com/ros/actionlib/blob/noetic-devel/actionlib/src/actionlib/action_client.py#L567